### PR TITLE
feature/ removed fastmail.fm from disposable emails

### DIFF
--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -570,7 +570,6 @@
 - fastchrysler.com
 - fasternet.biz
 - fastkawasaki.com
-- fastmail.fm
 - fastmazda.com
 - fastmitsubishi.com
 - fastnissan.com


### PR DESCRIPTION
Would be possible to remove fastmail.fm from the disposable domains? Looks like people use it on a frequent basis