### PR TITLE
Removed hushmail.com and naver.com from disposable emails

### DIFF
--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -783,7 +783,6 @@
 - hungpackage.com
 - hush.ai
 - hush.com
-- hushmail.com
 - hushmail.me
 - huskion.net
 - hvastudiesucces.nl
@@ -1162,7 +1161,6 @@
 - nanonym.ch
 - national.shitposting.agency
 - nationalgardeningclub.com
-- naver.com
 - negated.com
 - neomailbox.com
 - nepwk.com


### PR DESCRIPTION
We have issues with existing users that signed up with these 2 email providers.
[Hushmail](https://en.wikipedia.org/wiki/Hushmail)
[Naver (Hangul: 네이버) is a popular sponsored advertisement portal in South Korea, owned by Naver Corporation](https://en.wikipedia.org/wiki/Naver)