### PR TITLE
Allow the rest of the hushmail.com domains

### DIFF
--- a/pull_mailchecker_emails.rb
+++ b/pull_mailchecker_emails.rb
@@ -5,7 +5,7 @@ require "yaml"
 require "json"
 require "net/http"
 
-whitelisted_emails = %w(poczta.onet.pl fastmail.fm hushmail.com naver.com)
+whitelisted_emails = %w(poczta.onet.pl fastmail.fm hushmail.com hush.ai hush.com hushmail.me naver.com)
 
 existing_emails = YAML.load_file("vendor/disposable_emails.yml")
 

--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -782,9 +782,6 @@
 - hulapla.de
 - humaility.com
 - hungpackage.com
-- hush.ai
-- hush.com
-- hushmail.me
 - huskion.net
 - hvastudiesucces.nl
 - hwsye.net


### PR DESCRIPTION
The main domain was removed, so removing the extra domains seems reasonable: https://github.com/lisinge/valid_email2/pull/38