### PR TITLE
Removed National University of Singapore from the blacklist because it is a valid domain

### DIFF
--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -1321,7 +1321,6 @@
 - nubescontrol.com
 - nullbox.info
 - nurfuerspam.de
-- nus.edu.sg
 - nuts2trade.com
 - nwldx.com
 - ny7.me


### PR DESCRIPTION
Hi, 

The University of Singapore (http://nus.edu.sg/) is included in your list of disposable email domains. I've removed it in the PR because as far as I know it is a valid domain.

Thanks!