### PR TITLE
Ability to use a whitelist on MX check

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ class User < ActiveRecord::Base
 end
 ```
 
-To validate that the domain has a MX record:
+To validate that the domain has a MX record (you can also allow some domain to pass that check under vendor/mx_whitelist.yml):
 ```ruby
 validates :email, email: { mx: true }
 ```

--- a/lib/valid_email2.rb
+++ b/lib/valid_email2.rb
@@ -9,4 +9,9 @@ module ValidEmail2
     blacklist_file = "vendor/blacklist.yml"
     @@blacklist ||= File.exists?(blacklist_file) ? YAML.load_file(File.expand_path(blacklist_file)) : []
   end
+
+  def self.mx_whitelist
+    mx_whitelist_file = "vendor/mx_whitelist.yml"
+    @@mx_whitelist ||= File.exists?(mx_whitelist_file) ? YAML.load_file(File.expand_path(mx_whitelist_file)) : []
+  end
 end

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -39,6 +39,7 @@ module ValidEmail2
 
     def valid_mx?
       return false unless valid?
+      return true if domain_is_in?(ValidEmail2.mx_whitelist)
 
       mx = []
 
@@ -52,7 +53,8 @@ module ValidEmail2
     private
 
     def domain_is_in?(domain_list)
-      domain_list.select { |domain|
+      # Ensure domain_list is an array
+      (domain_list || []).select { |domain|
         address.domain =~ (/^(.*\.)*#{domain}$/i)
       }.any?
     end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -85,5 +85,10 @@ describe ValidEmail2 do
       user = TestUserMX.new(email: "foo@subdomain.gmail.com")
       user.valid?.should be_false
     end
+
+    it "should be valid when email is in the whitelist" do
+      user = TestUserMX.new(email: "foo@#{ValidEmail2.mx_whitelist.first}")
+      user.valid?.should be_true
+    end
   end
 end

--- a/valid_email2.gemspec
+++ b/valid_email2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 11.3.0"
   spec.add_development_dependency "rspec", "~> 2.14.1"
   spec.add_runtime_dependency "mail", "~> 2.5"
   spec.add_runtime_dependency "activemodel", ">= 3.2"

--- a/vendor/mx_whitelist.yml
+++ b/vendor/mx_whitelist.yml
@@ -1,0 +1,1 @@
+- whitelisted-test.com


### PR DESCRIPTION
## Context
We have a database of ~200000 active users that we migrated from an old app (very old) into our OAuth server, which is a Rails app. We implemented the gem to ensure new account will have a valid email address upon registration.

## Problem
Some of the accounts (still active) uses email address that are not valid anymore. Domain associated does not exists anymore. We have the case for exemple with several accounts using `dummyemail@voila.fr` which is not MX valid (but used to).
The problem is that when those users try to update their profile, their email address appears not to be valid.

## Solution
In order to still be able to block any non-valid MX domain upon registration and to support backward compatibility with old legacy data, we needed a way to whitelist some of the domain optionally.

==============================================================================

As this is a very specific case and as we normally should force users to change their email address (but how? since they cannot receive any email), I'm just suggesting this feature in case you'd be interested to have such option in that gem. Not sure it's necessary but it's possible people may encounter the same as us in the future. As this is optional, it does not break actual code.

Thanks