### PR TITLE
Fix compatibility issue with rake on travis

### DIFF
--- a/valid_email2.gemspec
+++ b/valid_email2.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.9.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "~> 11.3.0"
   spec.add_development_dependency "rspec", "~> 2.14.1"
   spec.add_runtime_dependency "mail", "~> 2.5"
   spec.add_runtime_dependency "activemodel", ">= 3.2"


### PR DESCRIPTION
Earlier today I created a pull request (https://github.com/lisinge/valid_email2/pull/57) regarding adding a whitelist of MX record (I closed the pull request by the way). One thing I realized was an issue with rake which causes travis check to fail. You can actually see the related failure here:
https://travis-ci.org/lisinge/valid_email2/jobs/183442214

This is a fix for it. Thanks