### PR TITLE
Improve performance of checking domains

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -52,9 +52,10 @@ module ValidEmail2
     private
 
     def domain_is_in?(domain_list)
-      domain_list.select { |domain|
-        address.domain =~ (/^(.*\.)*#{domain}$/i)
-      }.any?
+      address_domain = address.domain.downcase
+      domain_list.any? { |domain|
+        address_domain.end_with?(domain) && address_domain =~ /\A(?:.+\.)*?#{domain}\z/
+      }
     end
   end
 end


### PR DESCRIPTION
I need to analyse thousands of domains and it takes much time.

Some experiments:

```ruby
    def domain_is_in?(domain_list)
      domain_list.select { |domain|
        address.domain =~ (/\A(.*\.)*#{domain}\z/i)
      }.any?
    end

    def domain_is_in_2?(domain_list)
      domain_list.any? { |domain|
        address.domain =~ /\A(.*\.)*#{domain}\z/i
      }
    end

    def domain_is_in_3?(domain_list)
      address_domain = address.domain.downcase
      domain_list.any? { |domain|
        address_domain =~ /\A(?:.+\.)*?#{domain}\z/
      }
    end

    def domain_is_in_4?(domain_list)
      address_domain = address.domain.downcase
      domain_list.any? { |domain|
        address_domain.end_with?(domain) && address_domain =~ /\A(?:.+\.)*?#{domain}\z/
      }
    end
```

Code:
```ruby
a = ValidEmail2::Address.new 'alex...@gmail.com'

n = 100
Benchmark.bm do |x|
  x.report { n.times do ; a.disposable?; end }
  x.report { n.times do ; a.disposable2?; end }
  x.report { n.times do ; a.disposable3?; end }
  x.report { n.times do ; a.disposable4?; end }
end
```

Results:
```
       user     system      total        real
   3.520000   0.090000   3.610000 (  3.628667)
   3.450000   0.050000   3.500000 (  3.499219)
   2.460000   0.040000   2.500000 (  2.511812)
   0.020000   0.000000   0.020000 (  0.023849)
```

It looks like 100x improvement.