### PR TITLE
Namespace EmailValidator under the ValidEmail2 namespace.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.4.0
-  - 2.3.0
-  - 2.2.0
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
 
 gemfile:
   - gemfiles/activemodel3.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: ruby
 sudo: false
 
 rvm:
+  - 2.4.0
   - 2.3.0
   - 2.2.0
-  - 2.1.0
-  - 2.0.0
 
 gemfile:
   - gemfiles/activemodel3.gemfile
   - gemfiles/activemodel4.gemfile
+  - gemfiles/activemodel5.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 sudo: false
 
 rvm:
-  - 2.4.1
-  - 2.3.4
-  - 2.2.7
+  - 2.4
+  - 2.3
+  - 2.2
 
 gemfile:
   - gemfiles/activemodel3.gemfile

--- a/README.md
+++ b/README.md
@@ -39,28 +39,28 @@ Or install it yourself as:
 If you just want to validate that it is a valid email address:
 ```ruby
 class User < ActiveRecord::Base
-  validates :email, presence: true, email: true
+  validates :email, presence: true, 'valid_email_2/email': true
 end
 ```
 
 To validate that the domain has a MX record:
 ```ruby
-validates :email, email: { mx: true }
+validates :email, 'valid_email_2/email': { mx: true }
 ```
 
 To validate that the domain is not a disposable email:
 ```ruby
-validates :email, email: { disposable: true }
+validates :email, 'valid_email_2/email': { disposable: true }
 ```
 
 To validate that the domain is not blacklisted (under vendor/blacklist.yml):
 ```ruby
-validates :email, email: { blacklist: true }
+validates :email, 'valid_email_2/email': { blacklist: true }
 ```
 
 All together:
 ```ruby
-validates :email, email: { mx: true, disposable: true }
+validates :email, 'valid_email_2/email': { mx: true, disposable: true }
 ```
 
 > Note that this gem will let an empty email pass through so you will need to

--- a/gemfiles/activemodel4.gemfile
+++ b/gemfiles/activemodel4.gemfile
@@ -1,5 +1,5 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-gem "activemodel", "~> 4.2.0"
+gem 'activemodel', '~> 4.2.9'
 
-gemspec path: "../"
+gemspec path: '../'

--- a/gemfiles/activemodel5.gemfile
+++ b/gemfiles/activemodel5.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'activemodel', '~> 3.2.22'
+gem 'activemodel', '~> 5.1.2'
 
 gemspec path: '../'

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -1,0 +1,4 @@
+# This is a shim for keeping backwards compatibility.
+# See the discussion in: https://github.com/lisinge/valid_email2/pull/79
+class EmailValidator < ValidEmail2::EmailValidator
+end

--- a/lib/valid_email2.rb
+++ b/lib/valid_email2.rb
@@ -1,4 +1,5 @@
 require "valid_email2/email_validator"
+require "email_validator" # Backwards-compatibility shim
 
 module ValidEmail2
   def self.disposable_emails

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -2,33 +2,35 @@ require "valid_email2/address"
 require "active_model"
 require "active_model/validations"
 
-class EmailValidator < ActiveModel::EachValidator
-  def default_options
-    { regex: true, disposable: false, mx: false }
-  end
-
-  def validate_each(record, attribute, value)
-    return unless value.present?
-    options = default_options.merge(self.options)
-
-    address = ValidEmail2::Address.new(value)
-
-    error(record, attribute) && return unless address.valid?
-
-    if options[:disposable]
-      error(record, attribute) && return if address.disposable?
+module ValidEmail2
+  class EmailValidator < ActiveModel::EachValidator
+    def default_options
+      { regex: true, disposable: false, mx: false }
     end
 
-    if options[:blacklist]
-      error(record, attribute) && return if address.blacklisted?
+    def validate_each(record, attribute, value)
+      return unless value.present?
+      options = default_options.merge(self.options)
+
+      address = ValidEmail2::Address.new(value)
+
+      error(record, attribute) && return unless address.valid?
+
+      if options[:disposable]
+        error(record, attribute) && return if address.disposable?
+      end
+
+      if options[:blacklist]
+        error(record, attribute) && return if address.blacklisted?
+      end
+
+      if options[:mx]
+        error(record, attribute) && return unless address.valid_mx?
+      end
     end
 
-    if options[:mx]
-      error(record, attribute) && return unless address.valid_mx?
+    def error(record, attribute)
+      record.errors.add(attribute, options[:message] || :invalid)
     end
-  end
-
-  def error(record, attribute)
-    record.errors.add(attribute, options[:message] || :invalid)
   end
 end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -1,19 +1,19 @@
 require "spec_helper"
 
 class TestUser < TestModel
-  validates :email, email: true
+  validates :email, 'valid_email_2/email': true
 end
 
 class TestUserMX < TestModel
-  validates :email, email: { mx: true }
+  validates :email, 'valid_email_2/email': { mx: true }
 end
 
 class TestUserDisallowDisposable < TestModel
-  validates :email, email: { disposable: true }
+  validates :email, 'valid_email_2/email': { disposable: true }
 end
 
 class TestUserDisallowBlacklisted < TestModel
-  validates :email, email: { blacklist: true }
+  validates :email, 'valid_email_2/email': { blacklist: true }
 end
 
 describe ValidEmail2 do

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -16,6 +16,10 @@ class TestUserDisallowBlacklisted < TestModel
   validates :email, 'valid_email_2/email': { blacklist: true }
 end
 
+class BackwardsCompatibleUser < TestModel
+  validates :email, email: true
+end
+
 describe ValidEmail2 do
   describe "basic validation" do
     subject(:user) { TestUser.new(email: "") }
@@ -43,6 +47,11 @@ describe ValidEmail2 do
     it "shouldn't be valid if the domain constains consecutives dots" do
       user = TestUser.new(email: "foo@bar..com")
       expect(user.valid?).to be_falsey
+    end
+
+    it "still works with the backwards-compatible syntax" do
+      user = BackwardsCompatibleUser.new(email: "foo@bar.com")
+      expect(user.valid?).to be_truthy
     end
   end
 


### PR DESCRIPTION
This is a breaking change. The invocation changes from:

```
validates :email, email: true
```

to

```
validates :email, 'valid_email_2/email': true
```

This solves https://github.com/lisinge/valid_email2/issues/46