### PR TITLE
Validating the emails

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -6,6 +6,8 @@ module ValidEmail2
   class Address
     attr_accessor :address
 
+    VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+
     def initialize(address)
       @parse_error = false
       @raw_address = address
@@ -21,9 +23,7 @@ module ValidEmail2
       return false if @parse_error
 
       if address.domain && address.address == @raw_address
-        domain = address.domain
-        # Valid address needs to have a dot in the domain but not start with a dot
-        !!domain.match(/\./) && !domain.match(/\.{2,}/) && !domain.match(/^\./)
+        @raw_address.match? VALID_EMAIL_REGEX
       else
         false
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -98,4 +98,27 @@ describe ValidEmail2 do
       expect(user.valid?).to be_falsey
     end
   end
+
+  describe "without active model" do
+    it "should be invalid when email end with !" do
+      address = ValidEmail2::Address.new("foo@gmail.com!")
+      expect(address.valid?).to be_falsey
+    end
+
+    it "should be invalid if email has special characters just before domain" do
+      address = ValidEmail2::Address.new("foo@gmail+.com")
+      expect(address.valid?).to be_falsey
+    end
+
+    it "should be invalid when email has special characters in domain" do
+      address = ValidEmail2::Address.new("foo@gmail+yahoo.com")
+      expect(address.valid?).to be_falsey
+    end
+
+    it "should be valid email" do
+      address = ValidEmail2::Address.new("foo@gmail.com")
+      expect(address.valid?).to be_truthy
+    end
+  end
+
 end


### PR DESCRIPTION
Issue: `valid_email2` is not validating the emails correctly(without ActiveModel case).

I tried to fix email validating issue. Here is some comparison with old and current changings. In examples, most email addresses are not valid.

**Old**:

```
  email =  "foo@gmail+yahoo.com" 
  ValidEmail2::Address.new(email).valid?
   => true
```

If you see email id `foo@gmail+yahoo.com` it does not look correct, should not be valid email id.

**New**:

```
 email = "foo@gmail+yahoo.com" 
 ValidEmail2::Address.new(email).valid?
   => false
 
```
Another Example

**Old**:
```
 email = "foo@gmail.com!" 
 ValidEmail2::Address.new(email).valid?
   => true
 
```
**New**:
```
 email = "foo@gmail.com!" 
 ValidEmail2::Address.new(email).valid?
   => false
 
```

as **foo@gmail.com!** is invalid because email end with !