### PR TITLE
ValidEmail2 return false if email contain emoticons in email

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -21,6 +21,7 @@ module ValidEmail2
 
     def valid?
       return false if @parse_error
+      return false if address_contain_emoticons? @raw_address
 
       if address.domain && address.address == @raw_address
         domain = address.domain
@@ -64,6 +65,10 @@ module ValidEmail2
       domain_list.any? { |domain|
         address_domain.end_with?(domain) && address_domain =~ /\A(?:.+\.)*?#{domain}\z/
       }
+    end
+
+    def address_contain_emoticons? address
+      (address.each_char.select { |char| char.bytesize > 1 }.join).empty? ? false : true
     end
   end
 end

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -17,11 +17,12 @@ module ValidEmail2
       rescue Mail::Field::ParseError
         @parse_error = true
       end
+
+      @parse_error ||= address_contain_emoticons? @raw_address
     end
 
     def valid?
       return false if @parse_error
-      return false if address_contain_emoticons? @raw_address
 
       if address.domain && address.address == @raw_address
         domain = address.domain
@@ -67,8 +68,8 @@ module ValidEmail2
       }
     end
 
-    def address_contain_emoticons? address
-      (address.each_char.select { |char| char.bytesize > 1 }.join).empty? ? false : true
+    def address_contain_emoticons? email_str
+      (email_str.each_char.select { |char| char.bytesize > 1 }.join).empty? ? false : true
     end
   end
 end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -115,4 +115,17 @@ describe ValidEmail2 do
       expect(user.valid?).to be_falsey
     end
   end
+
+  describe "emoticons emails" do
+    it "should be invalid if email contains emoticon" do
+      email = ValidEmail2::Address.new("foo🙈@gmail.com")
+      expect(email.valid?).to be_falsy
+      end
+
+    it "should be invalid if email contains parsed emoticon" do
+      email = ValidEmail2::Address.new("foo:speak_no_evil:@gmail.com")
+      expect(email.valid?).to be_falsy
+    end
+
+  end
 end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -120,12 +120,6 @@ describe ValidEmail2 do
     it "should be invalid if email contains emoticon" do
       email = ValidEmail2::Address.new("foo🙈@gmail.com")
       expect(email.valid?).to be_falsy
-      end
-
-    it "should be invalid if email contains parsed emoticon" do
-      email = ValidEmail2::Address.new("foo:speak_no_evil:@gmail.com")
-      expect(email.valid?).to be_falsy
     end
-
   end
 end


### PR DESCRIPTION
[Issue-93](https://github.com/lisinge/valid_email2/issues/93)

If email address contains emoticons then ValidEmail2 was returning true. 

`
ValidEmail2::Address.new("abc🙈@bbc.com").valid? => true
`
It should return false.

I just fixed this issue. Please review the PR.