### PR TITLE
Remove qq.com from disposable_emails.yml

### DIFF
--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -2741,7 +2741,6 @@
 - qisoa.com
 - qj97r73md7v5.com
 - qoika.com
-- qq.com
 - qq.my
 - qs.dp76.com
 - qs2k.com


### PR DESCRIPTION
This is a valid email provider, mainly used in Asia.
https://www.quora.com/Are-QQMail-accounts-permanent

I've mentioned this on #96 - Until we get this figured out (or not!), I've figured we might as well remove this domain.