### PR TITLE
Remove protonmail.com from disposable emails

### DIFF
--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -2698,7 +2698,6 @@
 - proprietativalcea.ro
 - propscore.com
 - protempmail.com
-- protonmail.com
 - proxymail.eu
 - proxyparking.com
 - prs7.xyz


### PR DESCRIPTION
[https://protonmail.com/](https://protonmail.com/) is a valid email provider.
