### PR TITLE
Allow case of MX record fallback to A record

### DIFF
--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -48,13 +48,10 @@ module ValidEmail2
     def valid_mx?
       return false unless valid?
 
-      mx = []
-
       Resolv::DNS.open do |dns|
-        mx.concat dns.getresources(address.domain, Resolv::DNS::Resource::IN::MX)
+        return dns.getresources(address.domain, Resolv::DNS::Resource::IN::MX).size > 0 ||
+               dns.getresources(address.domain, Resolv::DNS::Resource::IN::A).size > 0
       end
-
-      mx.any?
     end
 
     private

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -110,6 +110,11 @@ describe ValidEmail2 do
       expect(user.valid?).to be_truthy
     end
 
+    it "should be valid if A records are found" do
+      user = TestUserMX.new(email: "foo@ghs.google.com")
+      expect(user.valid?).to be_truthy
+    end
+
     it "should be invalid if no mx records are found" do
       user = TestUserMX.new(email: "foo@subdomain.gmail.com")
       expect(user.valid?).to be_falsey


### PR DESCRIPTION
In section 5.1 of https://tools.ietf.org/html/rfc5321

> If an empty list of MXs is returned, the address is treated as if it was associated with an implicit MX RR

So in other words, checking only MX record is not enough.