### PR TITLE
Forbid address tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ address = ValidEmail2::Address.new("lisinge@gmail.com")
 address.valid? => true
 address.disposable? => false
 address.valid_mx? => true
-address.tagged? => false
+address.subaddressed? => false
 ```
 
 ### Test environment

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ validates :email, 'valid_email_2/email': { blacklist: true }
 
 To validate that email is not subaddressed (Forbid Email Address Tagging or Subaddressing):
 ```ruby
-validates :email, 'valid_email_2/email': { forbid_tagging: true }
+validates :email, 'valid_email_2/email': { disallow_subaddressing: true }
 ```
 
 All together:
 ```ruby
-validates :email, 'valid_email_2/email': { mx: true, disposable: true, forbid_tagging: true}
+validates :email, 'valid_email_2/email': { mx: true, disposable: true, disallow_subaddressing: true}
 ```
 
 > Note that this gem will let an empty email pass through so you will need to

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Validate emails with the help of the `mail` gem instead of some clunky regexp.
 Aditionally validate that the domain has a MX record.
 Optionally validate against a static [list of disposable email services](vendor/disposable_emails.yml).
-Optionally validate that the email is not subaddressed [RFC5233](https://tools.ietf.org/html/rfc5233).
+Optionally validate that the email is not subaddressed ([RFC5233](https://tools.ietf.org/html/rfc5233)).
 
 ### Why?
 
@@ -58,7 +58,7 @@ To validate that the domain is not blacklisted (under vendor/blacklist.yml):
 validates :email, 'valid_email_2/email': { blacklist: true }
 ```
 
-To validate that email is not subaddressed (Forbid Email Address Tagging or Subaddressing):
+To validate that email is not subaddressed:
 ```ruby
 validates :email, 'valid_email_2/email': { disallow_subaddressing: true }
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Validate emails with the help of the `mail` gem instead of some clunky regexp.
 Aditionally validate that the domain has a MX record.
 Optionally validate against a static [list of disposable email services](vendor/disposable_emails.yml).
-
+Optionally validate that the email is not subaddressed [RFC5233](https://tools.ietf.org/html/rfc5233).
 
 ### Why?
 
@@ -58,9 +58,14 @@ To validate that the domain is not blacklisted (under vendor/blacklist.yml):
 validates :email, 'valid_email_2/email': { blacklist: true }
 ```
 
+To validate that email is not subaddressed (Forbid Email Address Tagging or Subaddressing):
+```ruby
+validates :email, 'valid_email_2/email': { forbid_tagging: true }
+```
+
 All together:
 ```ruby
-validates :email, 'valid_email_2/email': { mx: true, disposable: true }
+validates :email, 'valid_email_2/email': { mx: true, disposable: true, forbid_tagging: true}
 ```
 
 > Note that this gem will let an empty email pass through so you will need to
@@ -73,6 +78,7 @@ address = ValidEmail2::Address.new("lisinge@gmail.com")
 address.valid? => true
 address.disposable? => false
 address.valid_mx? => true
+address.tagged? => false
 ```
 
 ### Test environment

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -40,6 +40,10 @@ module ValidEmail2
       end
     end
 
+    def tagged?
+      valid? && address.local.split(DEFAULT_RECIPIENT_DELIMITER).length > 1
+    end
+
     def disposable?
       valid? && domain_is_in?(ValidEmail2.disposable_emails)
     end

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -7,6 +7,7 @@ module ValidEmail2
     attr_accessor :address
 
     ALLOWED_DOMAIN_CHARACTERS_REGEX = /\A[a-z0-9\-.]+\z/i
+    DEFAULT_RECIPIENT_DELIMITER = '+'.freeze
 
     def initialize(address)
       @parse_error = false

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -40,7 +40,7 @@ module ValidEmail2
       end
     end
 
-    def tagged?
+    def subaddressed?
       valid? && address.local.include?(DEFAULT_RECIPIENT_DELIMITER)
     end
 

--- a/lib/valid_email2/address.rb
+++ b/lib/valid_email2/address.rb
@@ -41,7 +41,7 @@ module ValidEmail2
     end
 
     def tagged?
-      valid? && address.local.split(DEFAULT_RECIPIENT_DELIMITER).length > 1
+      valid? && address.local.include?(DEFAULT_RECIPIENT_DELIMITER)
     end
 
     def disposable?

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,7 +5,7 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { regex: true, disposable: false, mx: false, forbid_tagging: false }
+      { regex: true, disposable: false, mx: false, disallow_subaddressing: false }
     end
 
     def validate_each(record, attribute, value)
@@ -16,7 +16,7 @@ module ValidEmail2
 
       error(record, attribute) && return unless address.valid?
 
-      if options[:forbid_tagging]
+      if options[:disallow_subaddressing]
         error(record, attribute) && return if address.subaddressed?
       end
 

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,7 +5,7 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { regex: true, disposable: false, mx: false, restrict_tagging: false }
+      { regex: true, disposable: false, mx: false, forbid_tagging: false }
     end
 
     def validate_each(record, attribute, value)
@@ -16,7 +16,7 @@ module ValidEmail2
 
       error(record, attribute) && return unless address.valid?
 
-      if options[:restrict_tagging]
+      if options[:forbid_tagging]
         error(record, attribute) && return if address.tagged?
       end
 

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -17,7 +17,7 @@ module ValidEmail2
       error(record, attribute) && return unless address.valid?
 
       if options[:forbid_tagging]
-        error(record, attribute) && return if address.tagged?
+        error(record, attribute) && return if address.subaddressed?
       end
 
       if options[:disposable]

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -5,7 +5,7 @@ require "active_model/validations"
 module ValidEmail2
   class EmailValidator < ActiveModel::EachValidator
     def default_options
-      { regex: true, disposable: false, mx: false }
+      { regex: true, disposable: false, mx: false, restrict_tagging: false }
     end
 
     def validate_each(record, attribute, value)

--- a/lib/valid_email2/email_validator.rb
+++ b/lib/valid_email2/email_validator.rb
@@ -16,6 +16,10 @@ module ValidEmail2
 
       error(record, attribute) && return unless address.valid?
 
+      if options[:restrict_tagging]
+        error(record, attribute) && return if address.tagged?
+      end
+
       if options[:disposable]
         error(record, attribute) && return if address.disposable?
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -123,18 +123,18 @@ describe ValidEmail2 do
   describe "address tagged emails" do
 
     describe "::Address::DEFAULT_RECIPIENT_DELIMITER" do
-      it "should be '+'" do
+      it "should be recipient delimiter ('+')" do
         expect(ValidEmail2::Address::DEFAULT_RECIPIENT_DELIMITER).to eq('+')
       end
     end
 
     describe "::Address#tagged?" do
-      it "should be true when address local part contains a '+'" do
+      it "should be true when address local part contains a recipient delimiter ('+')" do
         email = ValidEmail2::Address.new("foo+1@gmail.com")
         expect(email.tagged?).to be_truthy
       end
 
-      it "should be false when address local part contains a '+'" do
+      it "should be false when address local part contains a recipient delimiter ('+')" do
         email = ValidEmail2::Address.new("foo@gmail.com")
         expect(email.tagged?).to be_falsey
       end
@@ -142,25 +142,25 @@ describe ValidEmail2 do
 
     describe "user validation" do
       context "restriction is disabled (default)" do
-        it "should be valid when address local part does not contain a '+'" do
+        it "should be valid when address local part does not contain a recipient delimiter ('+')" do
           user = TestUser.new(email: "foo@gmail.com")
           expect(user.valid?).to be_truthy
         end
 
-        it "should be valid when address local part contains a '+'" do
+        it "should be valid when address local part contains a recipient delimiter ('+')" do
           user = TestUser.new(email: "foo+1@gmail.com")
           expect(user.valid?).to be_truthy
         end
       end
 
       context "restriction is enabled" do
-        it "should be valid when address local part does not contain a '+'" do
-          user = TestUserRestrictTagging.new(email: "foo@gmail.com")
+        it "should be valid when address local part does not contain a recipient delimiter ('+')" do
+          user = TestUserForbidTagging.new(email: "foo@gmail.com")
           expect(user.valid?).to be_truthy
         end
 
-        it "should be invalid when address local part contains a '+'" do
-          user = TestUserRestrictTagging.new(email: "foo+1@gmail.com")
+        it "should be invalid when address local part contains a recipient delimiter ('+')" do
+          user = TestUserForbidTagging.new(email: "foo+1@gmail.com")
           expect(user.valid?).to be_falsey
         end
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -131,12 +131,12 @@ describe ValidEmail2 do
     describe "::Address#tagged?" do
       it "should be true when address local part contains a recipient delimiter ('+')" do
         email = ValidEmail2::Address.new("foo+1@gmail.com")
-        expect(email.tagged?).to be_truthy
+        expect(email.subaddressed?).to be_truthy
       end
 
       it "should be false when address local part contains a recipient delimiter ('+')" do
         email = ValidEmail2::Address.new("foo@gmail.com")
-        expect(email.tagged?).to be_falsey
+        expect(email.subaddressed?).to be_falsey
       end
     end
 

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -119,4 +119,52 @@ describe ValidEmail2 do
       expect(email.valid?).to be_falsy
     end
   end
+
+  describe "address tagged emails" do
+
+    describe "::Address::DEFAULT_RECIPIENT_DELIMITER" do
+      it "should be '+'" do
+        expect(ValidEmail2::Address::DEFAULT_RECIPIENT_DELIMITER).to eq('+')
+      end
+    end
+
+    describe "::Address#tagged?" do
+      it "should be true when address local part contains a '+'" do
+        email = ValidEmail2::Address.new("foo+1@gmail.com")
+        expect(email.tagged?).to be_truthy
+      end
+
+      it "should be false when address local part contains a '+'" do
+        email = ValidEmail2::Address.new("foo@gmail.com")
+        expect(email.tagged?).to be_falsey
+      end
+    end
+
+    describe "user validation" do
+      context "restriction is disabled (default)" do
+        it "should be valid when address local part does not contain a '+'" do
+          user = TestUser.new(email: "foo@gmail.com")
+          expect(user.valid?).to be_truthy
+        end
+
+        it "should be valid when address local part contains a '+'" do
+          user = TestUser.new(email: "foo+1@gmail.com")
+          expect(user.valid?).to be_truthy
+        end
+      end
+
+      context "restriction is enabled" do
+        it "should be valid when address local part does not contain a '+'" do
+          user = TestUserRestrictTagging.new(email: "foo@gmail.com")
+          expect(user.valid?).to be_truthy
+        end
+
+        it "should be invalid when address local part contains a '+'" do
+          user = TestUserRestrictTagging.new(email: "foo+1@gmail.com")
+          expect(user.valid?).to be_falsey
+        end
+      end
+    end
+
+  end
 end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -120,7 +120,7 @@ describe ValidEmail2 do
     end
   end
 
-  describe "address tagged emails" do
+  describe "subaddressed emails" do
 
     describe "::Address::DEFAULT_RECIPIENT_DELIMITER" do
       it "should be recipient delimiter ('+')" do
@@ -128,7 +128,7 @@ describe ValidEmail2 do
       end
     end
 
-    describe "::Address#tagged?" do
+    describe "::Address#subaddressed?" do
       it "should be true when address local part contains a recipient delimiter ('+')" do
         email = ValidEmail2::Address.new("foo+1@gmail.com")
         expect(email.subaddressed?).to be_truthy
@@ -141,7 +141,7 @@ describe ValidEmail2 do
     end
 
     describe "user validation" do
-      context "restriction is disabled (default)" do
+      context "subaddressing is allowed (default)" do
         it "should be valid when address local part does not contain a recipient delimiter ('+')" do
           user = TestUser.new(email: "foo@gmail.com")
           expect(user.valid?).to be_truthy
@@ -153,7 +153,7 @@ describe ValidEmail2 do
         end
       end
 
-      context "restriction is enabled" do
+      context "subaddressing is forbidden" do
         it "should be valid when address local part does not contain a recipient delimiter ('+')" do
           user = TestUserSubaddressing.new(email: "foo@gmail.com")
           expect(user.valid?).to be_truthy

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -4,8 +4,8 @@ class TestUser < TestModel
   validates :email, 'valid_email_2/email': true
 end
 
-class TestUserRestrictTagging < TestModel
-  validates :email, 'valid_email_2/email': {restrict_tagging: true}
+class TestUserForbidTagging < TestModel
+  validates :email, 'valid_email_2/email': {forbid_tagging: true}
 end
 
 class TestUserMX < TestModel

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -5,7 +5,7 @@ class TestUser < TestModel
 end
 
 class TestUserForbidTagging < TestModel
-  validates :email, 'valid_email_2/email': {forbid_tagging: true}
+  validates :email, 'valid_email_2/email': {disallow_subaddressing: true}
 end
 
 class TestUserMX < TestModel

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -4,7 +4,7 @@ class TestUser < TestModel
   validates :email, 'valid_email_2/email': true
 end
 
-class TestUserForbidTagging < TestModel
+class TestUserSubaddressing < TestModel
   validates :email, 'valid_email_2/email': {disallow_subaddressing: true}
 end
 
@@ -155,12 +155,12 @@ describe ValidEmail2 do
 
       context "restriction is enabled" do
         it "should be valid when address local part does not contain a recipient delimiter ('+')" do
-          user = TestUserForbidTagging.new(email: "foo@gmail.com")
+          user = TestUserSubaddressing.new(email: "foo@gmail.com")
           expect(user.valid?).to be_truthy
         end
 
         it "should be invalid when address local part contains a recipient delimiter ('+')" do
-          user = TestUserForbidTagging.new(email: "foo+1@gmail.com")
+          user = TestUserSubaddressing.new(email: "foo+1@gmail.com")
           expect(user.valid?).to be_falsey
         end
       end

--- a/spec/valid_email2_spec.rb
+++ b/spec/valid_email2_spec.rb
@@ -4,6 +4,10 @@ class TestUser < TestModel
   validates :email, 'valid_email_2/email': true
 end
 
+class TestUserRestrictTagging < TestModel
+  validates :email, 'valid_email_2/email': {restrict_tagging: true}
+end
+
 class TestUserMX < TestModel
   validates :email, 'valid_email_2/email': { mx: true }
 end


### PR DESCRIPTION
Some well known email providers, such as Gmail, support email address tagging (example+hello@gmail.com --> example@gmail.com). This is a really great feature, but also causes problems to manage user accounts (e.g. duplicates).

This PR provides the feature to forbid email address tagging. By default email address tagging is allowed. 

To validate that the email address is not tagged add this to your ActiveModel:
```
validates :email, 'valid_email_2/email': { forbid_tagging: true }
```
**Without ActiveModel:**
```
address = ValidEmail2::Address.new("example+hello@gmail.com")
address.tagged? => true
```
It would be nice to merge this PR to this great gem.