### PR TITLE
Update disposable_emails.yml

### DIFF
--- a/vendor/disposable_emails.yml
+++ b/vendor/disposable_emails.yml
@@ -2785,6 +2785,7 @@
 - letthemeatspam.com
 - levy.ml
 - lexisense.com
+- lexxip.com
 - lez.se
 - lgxscreen.com
 - lhsdv.com


### PR DESCRIPTION
lexxip.com/mail allows you to create throwaway email accounts on the lexxip.com domain.